### PR TITLE
feat: add shared Thymeleaf layout components

### DIFF
--- a/backend/SLLBackend/src/main/resources/templates/fragments/README-staff-sidebar.md
+++ b/backend/SLLBackend/src/main/resources/templates/fragments/README-staff-sidebar.md
@@ -1,0 +1,203 @@
+# Staff Sidebar Fragment
+
+
+Fragment sidebar dành riêng cho các trang staff, cung cấp navigation thống nhất và dễ bảo trì.
+
+
+## Cách sử dụng
+
+
+### 1. Import fragment vào trang HTML
+
+
+```html
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title th:text="#{staff.products.title} + ' | ' + #{app.name}">Staff - Manage Products | Salon Loan Loan</title>
+   
+    <!-- Bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" />
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="d-flex">
+        <!-- Sidebar Fragment -->
+        <div th:replace="fragments/staff-sidebar :: staff-sidebar"></div>
+
+
+        <!-- Main Content -->
+        <div class="main-content">
+            <!-- Header Fragment -->
+            <div th:replace="fragments/staff-sidebar :: staff-header"></div>
+
+
+            <!-- Content -->
+            <div class="content">
+                <!-- Nội dung trang của bạn -->
+            </div>
+        </div>
+    </div>
+
+
+    <!-- Scripts Fragment -->
+    <div th:replace="fragments/staff-sidebar :: staff-scripts"></div>
+</body>
+</html>
+```
+
+
+### 2. Các fragment có sẵn
+
+
+#### `staff-sidebar`
+- Sidebar navigation với logo
+- Menu items với submenu
+- Auto-expand active submenu
+- Mobile responsive
+
+
+#### `staff-header`
+- Header với nút Back
+- User info và dropdown menu
+- Mobile menu toggle
+
+
+#### `staff-scripts`
+- JavaScript cho mobile menu toggle
+- Submenu toggle functionality
+- Auto-expand active submenu
+
+
+### 3. Cấu trúc menu
+
+
+Sidebar bao gồm các menu chính:
+
+
+- **Manage Products** (Quản lý sản phẩm)
+  - Product List
+  - Add Product
+  - Edit Product
+
+
+- **Manage Services** (Quản lý dịch vụ)
+  - Service List
+  - Add Service
+  - Edit Service
+
+
+- **Manage Promotions** (Quản lý khuyến mãi)
+  - Promotion List
+  - Add Promotion
+
+
+- **Manage Providers** (Quản lý nhà cung cấp)
+  - Provider List
+  - Add Provider
+
+
+- **Profile** (Thông tin cá nhân)
+
+
+### 4. Active state
+
+
+Fragment tự động xác định trang hiện tại và đánh dấu active state:
+
+
+```html
+<!-- Tự động active khi URL chứa '/staff/products/list' -->
+<a th:href="@{/staff/products/list}" class="nav-submenu-item"
+   th:classappend="${#httpServletRequest.requestURI.contains('/staff/products/list')} ? 'active' : ''">
+    <span th:text="#{staff.products.list}">Product List</span>
+</a>
+```
+
+
+### 5. i18n Keys cần thiết
+
+
+Đảm bảo có các keys sau trong `messages.properties` và `messages_vi.properties`:
+
+
+```properties
+# App name
+app.name=Salon Loan Loan
+
+
+# Staff sections
+staff.products.title=Manage Products
+staff.products.list=Product List
+staff.products.create=Add Product
+staff.products.edit.title=Edit Product
+
+
+staff.services.title=Manage Services
+staff.services.list=Service List
+staff.services.create=Add Service
+staff.services.edit.title=Edit Service
+
+
+staff.promotions.title=Manage Promotions
+staff.promotions.list=Promotion List
+staff.promotions.create=Add Promotion
+
+
+staff.providers.title=Manage Providers
+staff.providers.list=Provider List
+staff.providers.create=Add Provider
+
+
+staff.profile.title=Profile
+staff.profile.edit.title=Edit Profile
+
+
+staff.welcome=Welcome, Staff
+
+
+# Buttons
+btn.back=Back
+btn.logout=Logout
+```
+
+
+### 6. CSS
+
+
+Fragment sử dụng `staff-sidebar.css` với các CSS variables để dễ tùy chỉnh:
+
+
+```css
+:root {
+    --sidebar-width: 280px;
+    --sidebar-bg: #2c3e50;
+    --sidebar-text: #ecf0f1;
+    --sidebar-hover: #34495e;
+    --sidebar-active: #3498db;
+    /* ... */
+}
+```
+
+
+### 7. Responsive Design
+
+
+- Desktop: Sidebar cố định bên trái
+- Mobile: Sidebar ẩn/hiện với toggle button
+- Tablet: Sidebar có thể thu gọn
+
+
+### 8. Lợi ích
+
+
+- **Tái sử dụng**: Một fragment cho tất cả trang staff
+- **Đồng bộ**: Thay đổi một lần, áp dụng cho tất cả
+- **Bảo trì**: Dễ dàng cập nhật menu và styling
+- **Responsive**: Tự động adapt với mọi kích thước màn hình
+- **i18n**: Hỗ trợ đa ngôn ngữ hoàn chỉnh

--- a/backend/SLLBackend/src/main/resources/templates/fragments/footer.html
+++ b/backend/SLLBackend/src/main/resources/templates/fragments/footer.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+
+<body>
+
+
+    <!-- ========== FOOTER ========== -->
+    <footer class="site-footer text-light" th:fragment="footer">
+        <div class="container py-5">
+            <div class="row g-4">
+                <div class="col-md-3">
+                    <div class="footer-brand d-flex align-items-center gap-2">
+                        <img th:src="@{/img/logo.jpg}" class="logo-img" th:alt="#{app.name}">
+                        <strong th:text="#{app.name}">Salon Loan Loan</strong>
+                    </div>
+                    <p class="small mt-3" th:text="#{app.tagline}">Your trusted hair salon for premium services</p>
+                    <div class="socials">
+                        <a href="#" class="social-link" th:title="#{social.facebook}"><i
+                                class="fab fa-facebook"></i></a>
+                        <a href="#" class="social-link" th:title="#{social.instagram}"><i
+                                class="fab fa-instagram"></i></a>
+                        <a href="#" class="social-link" th:title="#{social.tiktok}"><i class="fab fa-tiktok"></i></a>
+                    </div>
+                </div>
+
+
+                <div class="col-md-3">
+                    <h6 th:text="#{footer.quick.links}">Quick Links</h6>
+                    <ul class="footer-links">
+                        <li><a href="/" th:text="#{nav.home}">Home</a></li>
+                        <li><a href="/services" th:text="#{nav.services}">Services</a></li>
+                        <li><a href="/products" th:text="#{nav.products}">Products</a></li>
+                    </ul>
+                </div>
+
+
+                <div class="col-md-3">
+                    <h6 th:text="#{footer.working.hours}">Working Hours</h6>
+                    <p class="small mb-1" th:text="#{footer.working.hours.weekdays}">Mon - Fri: 9:00 AM - 8:00 PM</p>
+                    <p class="small mb-1" th:text="#{footer.working.hours.weekends}">Sat - Sun: 9:00 AM - 6:00 PM</p>
+                </div>
+
+
+                <div class="col-md-3">
+                    <h6 th:text="#{footer.contact}">Contact</h6>
+                    <p class="small mb-1" th:text="#{header.email}">info@salonloanloan.com</p>
+                    <p class="small mb-1" th:text="#{header.phone}">+84 123 456 789</p>
+                </div>
+            </div>
+        </div>
+
+
+        <div class="footer-bottom">
+            <div class="container d-flex justify-content-between small">
+                <span th:text="#{footer.privacy.policy}">Privacy Policy</span>
+                <span th:text="#{footer.terms.of.use}">Terms of Use</span>
+            </div>
+        </div>
+    </footer>
+
+
+</body>
+
+
+</html>

--- a/backend/SLLBackend/src/main/resources/templates/fragments/header.html
+++ b/backend/SLLBackend/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+
+<body>
+
+
+    <!-- ========== TOP HEADER ========== -->
+    <header class="top-header bg-black text-white" th:fragment="top-header">
+        <div class="container">
+            <div class="top-left">
+                <span id="siteEmail"><i class="fa-solid fa-envelope"></i> <span
+                        th:text="#{header.email}">info@salonloanloan.com</span></span>
+                <span id="sitePhone"><i class="fa-solid fa-phone"></i> <span th:text="#{header.phone}">+84 123 456 789</span></span>
+            </div>
+            <div class="top-right">
+                <a href="/contact" th:title="#{footer.contact}"><i class="fa-regular fa-comment"></i></a>
+                <span sec:authorize="!isAuthenticated()">
+                    <a th:href="@{/auth/user/login}" th:title="#{home.nav.user.login}"><i class="fa-regular fa-user"></i></a>
+                </span>
+                <!-- Authenticated user dropdown is intentionally hidden on the top header -->
+                <a href="/cart" th:title="#{cart.page.title}"><i class="fa-solid fa-cart-shopping"></i></a>
+            </div>
+        </div>
+    </header>
+
+
+    <!-- ========== NAVBAR ========== -->
+    <nav class="navbar navbar-expand-lg bg-white py-3 shadow-sm sticky-top" th:fragment="navbar">
+        <div class="container">
+            <div class="navbar-brand d-flex align-items-center">
+                <img th:src="@{/img/logo.jpg}" class="logo-img" th:alt="#{app.name}">
+            </div>
+
+
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+
+
+            <div class="collapse navbar-collapse" id="mainNav">
+                <ul id="mainMenu" class="navbar-nav gap-lg-5 align-items-lg-center">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/" th:text="#{nav.home}">Home</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/services" th:text="#{nav.services}">Services</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/products" th:text="#{nav.products}">Products</a>
+                    </li>
+                </ul>
+                <div class="navbar-actions d-flex align-items-center gap-2" sec:authorize="!isAuthenticated()">
+                    <a class="btn btn-sm btn-outline-dark rounded-pill px-3" th:href="@{/auth/user/login}" th:text="#{home.nav.user.login}">User Login</a>
+                    <a class="btn btn-sm btn-dark rounded-pill px-3" th:href="@{/auth/staff/login}" th:text="#{home.nav.staff.login}">Staff Login</a>
+                </div>
+                <div class="navbar-actions d-flex align-items-center gap-2" sec:authorize="isAuthenticated()">
+                    <div class="dropdown">
+                        <a class="btn btn-sm btn-outline-dark dropdown-toggle rounded-pill px-3" href="#" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="fa-regular fa-user"></i>
+                            <span sec:authentication="name">User</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            <!-- User Profile Link -->
+                            <li sec:authorize="hasRole('USER')">
+                                <a class="dropdown-item text-dark" th:href="@{/user/profile}" th:text="#{profile.title}">Profile</a>
+                            </li>
+                            <!-- Staff Profile Link -->
+                            <li sec:authorize="hasAnyRole('STAFF', 'MANAGER', 'ADMIN')">
+                                <a class="dropdown-item text-dark" th:href="@{/staff/profile}" th:text="#{profile.title}">Profile</a>
+                            </li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><a class="dropdown-item" th:href="@{/logout}" th:text="#{btn.logout}">Logout</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+
+</body>
+
+
+</html>

--- a/backend/SLLBackend/src/main/resources/templates/fragments/staff-sidebar.html
+++ b/backend/SLLBackend/src/main/resources/templates/fragments/staff-sidebar.html
@@ -1,0 +1,495 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+
+
+<!-- Staff Sidebar Fragment -->
+<div th:fragment="staff-sidebar" class="sidebar">
+    <div class="sidebar-header">
+        <div class="logo">
+            <h4 th:text="#{app.name}">Salon Loan Loan</h4>
+        </div>
+        <div class="header-actions">
+            <button id="sidebarCollapseBtn" class="collapse-toggle" type="button" aria-label="Collapse sidebar">
+                <i class="fas fa-angles-left"></i>
+            </button>
+            <button class="menu-toggle d-md-none" type="button" aria-label="Toggle menu">
+                <i class="fas fa-bars"></i>
+            </button>
+        </div>
+    </div>
+   
+    <nav class="sidebar-nav">
+        <!-- Manage Products -->
+        <div class="nav-item">
+            <a href="#" class="nav-link" data-toggle="submenu" data-target="products-submenu">
+                <i class="fas fa-box"></i>
+                <span th:text="#{staff.products.title}">Manage Products</span>
+                <i class="fas fa-chevron-down"></i>
+            </a>
+            <div class="nav-submenu" id="products-submenu">
+                <a th:href="@{/staff/products/list}" class="nav-submenu-item">
+                    <span th:text="#{staff.products.list}">Product List</span>
+                </a>
+                <a th:href="@{/staff/products/create}" class="nav-submenu-item">
+                    <span th:text="#{staff.products.create}">Add Product</span>
+                </a>
+            </div>
+        </div>
+
+
+        <!-- Manage Services -->
+        <div class="nav-item">
+            <a href="#" class="nav-link" data-toggle="submenu" data-target="services-submenu">
+                <i class="fas fa-concierge-bell"></i>
+                <span th:text="#{staff.services.title}">Manage Services</span>
+                <i class="fas fa-chevron-down"></i>
+            </a>
+            <div class="nav-submenu" id="services-submenu">
+                <a th:href="@{/staff/service/list}" class="nav-submenu-item">
+                    <span th:text="#{staff.services.list}">Service List</span>
+                </a>
+                <a th:href="@{/staff/service/create}" class="nav-submenu-item">
+                    <span th:text="#{staff.services.create}">Add Service</span>
+                </a>
+            </div>
+        </div>
+
+
+        <!-- Manage Promotions -->
+        <div class="nav-item">
+            <a href="#" class="nav-link" data-toggle="submenu" data-target="promotions-submenu">
+                <i class="fas fa-percentage"></i>
+                <span th:text="#{staff.promotions.title}">Manage Promotions</span>
+                <i class="fas fa-chevron-down"></i>
+            </a>
+            <div class="nav-submenu" id="promotions-submenu">
+                <a th:href="@{/staff/promotion/list}" class="nav-submenu-item">
+                    <span th:text="#{staff.promotions.list}">Promotion List</span>
+                </a>
+                <a th:href="@{/staff/promotion/create}" class="nav-submenu-item">
+                    <span th:text="#{staff.promotions.create}">Add Promotion</span>
+                </a>
+            </div>
+        </div>
+
+
+        <!-- Manage Providers -->
+        <div class="nav-item">
+            <a href="#" class="nav-link" data-toggle="submenu" data-target="providers-submenu">
+                <i class="fas fa-truck"></i>
+                <span th:text="#{staff.providers.title}">Manage Providers</span>
+                <i class="fas fa-chevron-down"></i>
+            </a>
+            <div class="nav-submenu" id="providers-submenu">
+                <a th:href="@{/staff/supplier/list}" class="nav-submenu-item">
+                    <span th:text="#{staff.providers.list}">Provider List</span>
+                </a>
+                <a th:href="@{/staff/supplier/create}" class="nav-submenu-item">
+                    <span th:text="#{staff.providers.create}">Add Provider</span>
+                </a>
+            </div>
+        </div>
+
+
+        <!-- Manage Vouchers -->
+        <div class="nav-item">
+            <a href="#" class="nav-link" data-toggle="submenu" data-target="vouchers-submenu">
+                <i class="fas fa-ticket-alt"></i>
+                <span th:text="#{staff.vouchers.title}">Manage Vouchers</span>
+                <i class="fas fa-chevron-down"></i>
+            </a>
+            <div class="nav-submenu" id="vouchers-submenu">
+                <a th:href="@{/staff/voucher/list}" class="nav-submenu-item">
+                    <span th:text="#{staff.vouchers.list}">Voucher List</span>
+                </a>
+                <a th:href="@{/staff/voucher/create}" class="nav-submenu-item">
+                    <span th:text="#{staff.vouchers.create}">Add Voucher</span>
+                </a>
+            </div>
+        </div>
+
+
+        <!-- Manage Jobs -->
+        <div class="nav-item">
+            <a href="#" class="nav-link" data-toggle="submenu" data-target="jobs-submenu">
+                <i class="fas fa-briefcase"></i>
+                <span th:text="#{staff.jobs.title}">Manage Jobs</span>
+                <i class="fas fa-chevron-down"></i>
+            </a>
+            <div class="nav-submenu" id="jobs-submenu">
+                <a th:href="@{/staff/job/list}" class="nav-submenu-item">
+                    <span th:text="#{staff.jobs.applications}">Job Applications</span>
+                </a>
+            </div>
+        </div>
+
+
+        <!-- Profile -->
+        <div class="nav-item">
+            <a th:href="@{/staff/profile}" class="nav-link">
+                <i class="fas fa-user"></i>
+                <span th:text="#{staff.profile.title}">Profile</span>
+            </a>
+        </div>
+    </nav>
+</div>
+
+
+<!-- Staff Header Fragment -->
+<div th:fragment="staff-header" class="header staff-layout-header">
+    <div class="header-left">
+        <button class="menu-toggle d-md-none">
+            <i class="fas fa-bars"></i>
+        </button>
+        <a th:href="@{/auth/staff/landing}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left"></i>
+            <span th:text="#{btn.back}">Back</span>
+        </a>
+    </div>
+    <div class="header-right">
+        <div class="user-info">
+            <span th:text="#{staff.welcome}">Welcome, Staff</span>
+        </div>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                <i class="fas fa-user"></i>
+                <span th:text="${session.staff?.staffName ?: 'Staff'}">Staff</span>
+            </button>
+            <ul class="dropdown-menu">
+                <li><a class="dropdown-item" th:href="@{/staff/profile}">
+                    <i class="fas fa-user me-2"></i>
+                    <span th:text="#{staff.profile.title}">Profile</span>
+                </a></li>
+                <li><a class="dropdown-item" th:href="@{/staff/profile/edit}">
+                    <i class="fas fa-edit me-2"></i>
+                    <span th:text="#{staff.profile.edit.title}">Edit Profile</span>
+                </a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" th:href="@{/auth/logout}">
+                    <i class="fas fa-sign-out-alt me-2"></i>
+                    <span th:text="#{btn.logout}">Logout</span>
+                </a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<!-- Staff Header with Add Service Button -->
+<div th:fragment="staff-header-with-add-service" class="header staff-layout-header">
+    <div class="header-left">
+        <button class="menu-toggle d-md-none">
+            <i class="fas fa-bars"></i>
+        </button>
+        <a th:href="@{/auth/staff/landing}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left"></i>
+            <span th:text="#{btn.back}">Back</span>
+        </a>
+    </div>
+    <div class="header-right">
+        <div class="user-info">
+            <span th:text="#{staff.welcome}">Welcome, Staff</span>
+        </div>
+        <a th:href="@{/staff/service/create}" class="btn btn-primary">
+            <i class="fas fa-plus"></i>
+            <span th:text="#{staff.services.create}">Add Service</span>
+        </a>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                <i class="fas fa-user"></i>
+                <span th:text="${session.staff?.staffName ?: 'Staff'}">Staff</span>
+            </button>
+            <ul class="dropdown-menu">
+                <li><a class="dropdown-item" th:href="@{/staff/profile}">
+                    <i class="fas fa-user me-2"></i>
+                    <span th:text="#{staff.profile.title}">Profile</span>
+                </a></li>
+                <li><a class="dropdown-item" th:href="@{/staff/profile/edit}">
+                    <i class="fas fa-edit me-2"></i>
+                    <span th:text="#{staff.profile.edit.title}">Edit Profile</span>
+                </a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" th:href="@{/auth/logout}">
+                    <i class="fas fa-sign-out-alt me-2"></i>
+                    <span th:text="#{btn.logout}">Logout</span>
+                </a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<!-- Staff Header with Add Product Button -->
+<div th:fragment="staff-header-with-add-product" class="header staff-layout-header">
+    <div class="header-left">
+        <button class="menu-toggle d-md-none">
+            <i class="fas fa-bars"></i>
+        </button>
+        <a th:href="@{/auth/staff/landing}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left"></i>
+            <span th:text="#{btn.back}">Back</span>
+        </a>
+    </div>
+    <div class="header-right">
+        <div class="user-info">
+            <span th:text="#{staff.welcome}">Welcome, Staff</span>
+        </div>
+        <a th:href="@{/staff/products/create}" class="btn btn-primary">
+            <i class="fas fa-plus"></i>
+            <span th:text="#{staff.products.create}">Add Product</span>
+        </a>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                <i class="fas fa-user"></i>
+                <span th:text="${session.staff?.staffName ?: 'Staff'}">Staff</span>
+            </button>
+            <ul class="dropdown-menu">
+                <li><a class="dropdown-item" th:href="@{/staff/profile}">
+                    <i class="fas fa-user me-2"></i>
+                    <span th:text="#{staff.profile.title}">Profile</span>
+                </a></li>
+                <li><a class="dropdown-item" th:href="@{/staff/profile/edit}">
+                    <i class="fas fa-edit me-2"></i>
+                    <span th:text="#{staff.profile.edit.title}">Edit Profile</span>
+                </a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" th:href="@{/auth/logout}">
+                    <i class="fas fa-sign-out-alt me-2"></i>
+                    <span th:text="#{btn.logout}">Logout</span>
+                </a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<!-- Staff Header with Add Promotion Button -->
+<div th:fragment="staff-header-with-add-promotion" class="header staff-layout-header">
+    <div class="header-left">
+        <button class="menu-toggle d-md-none">
+            <i class="fas fa-bars"></i>
+        </button>
+        <a th:href="@{/auth/staff/landing}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left"></i>
+            <span th:text="#{btn.back}">Back</span>
+        </a>
+    </div>
+    <div class="header-right">
+        <div class="user-info">
+            <span th:text="#{staff.welcome}">Welcome, Staff</span>
+        </div>
+        <a th:href="@{/staff/promotion/create}" class="btn btn-primary">
+            <i class="fas fa-plus"></i>
+            <span th:text="#{staff.promotions.create.button}">Create New Promotion</span>
+        </a>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                <i class="fas fa-user"></i>
+                <span th:text="${session.staff?.staffName ?: 'Staff'}">Staff</span>
+            </button>
+            <ul class="dropdown-menu">
+                <li><a class="dropdown-item" th:href="@{/staff/profile}">
+                    <i class="fas fa-user me-2"></i>
+                    <span th:text="#{staff.profile.title}">Profile</span>
+                </a></li>
+                <li><a class="dropdown-item" th:href="@{/staff/profile/edit}">
+                    <i class="fas fa-edit me-2"></i>
+                    <span th:text="#{staff.profile.edit.title}">Edit Profile</span>
+                </a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" th:href="@{/auth/logout}">
+                    <i class="fas fa-sign-out-alt me-2"></i>
+                    <span th:text="#{btn.logout}">Logout</span>
+                </a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<!-- Staff Header with Add Provider Button -->
+<div th:fragment="staff-header-with-add-provider" class="header staff-layout-header">
+    <div class="header-left">
+        <button class="menu-toggle d-md-none">
+            <i class="fas fa-bars"></i>
+        </button>
+        <a th:href="@{/auth/staff/landing}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left"></i>
+            <span th:text="#{btn.back}">Back</span>
+        </a>
+    </div>
+    <div class="header-right">
+        <div class="user-info">
+            <span th:text="#{staff.welcome}">Welcome, Staff</span>
+        </div>
+        <a th:href="@{/staff/supplier/create}" class="btn btn-primary">
+            <i class="fas fa-plus"></i>
+            <span th:text="#{staff.providers.create.button}">Create New Provider</span>
+        </a>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                <i class="fas fa-user"></i>
+                <span th:text="${session.staff?.staffName ?: 'Staff'}">Staff</span>
+            </button>
+            <ul class="dropdown-menu">
+                <li><a class="dropdown-item" th:href="@{/staff/profile}">
+                    <i class="fas fa-user me-2"></i>
+                    <span th:text="#{staff.profile.title}">Profile</span>
+                </a></li>
+                <li><a class="dropdown-item" th:href="@{/staff/profile/edit}">
+                    <i class="fas fa-edit me-2"></i>
+                    <span th:text="#{staff.profile.edit.title}">Edit Profile</span>
+                </a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" th:href="@{/auth/logout}">
+                    <i class="fas fa-sign-out-alt me-2"></i>
+                    <span th:text="#{btn.logout}">Logout</span>
+                </a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<!-- Staff Header with Add Voucher Button -->
+<div th:fragment="staff-header-with-add-voucher" class="header staff-layout-header">
+    <div class="header-left">
+        <button class="menu-toggle d-md-none">
+            <i class="fas fa-bars"></i>
+        </button>
+        <a th:href="@{/auth/staff/landing}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left"></i>
+            <span th:text="#{btn.back}">Back</span>
+        </a>
+    </div>
+    <div class="header-right">
+        <div class="user-info">
+            <span th:text="#{staff.welcome}">Welcome, Staff</span>
+        </div>
+        <a th:href="@{/staff/voucher/create}" class="btn btn-primary">
+            <i class="fas fa-plus"></i>
+            <span th:text="#{staff.vouchers.create.button}">Create New Voucher</span>
+        </a>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                <i class="fas fa-user"></i>
+                <span th:text="${session.staff?.staffName ?: 'Staff'}">Staff</span>
+            </button>
+            <ul class="dropdown-menu">
+                <li><a class="dropdown-item" th:href="@{/staff/profile}">
+                    <i class="fas fa-user me-2"></i>
+                    <span th:text="#{staff.profile.title}">Profile</span>
+                </a></li>
+                <li><a class="dropdown-item" th:href="@{/staff/profile/edit}">
+                    <i class="fas fa-edit me-2"></i>
+                    <span th:text="#{staff.profile.edit.title}">Edit Profile</span>
+                </a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" th:href="@{/auth/logout}">
+                    <i class="fas fa-sign-out-alt me-2"></i>
+                    <span th:text="#{btn.logout}">Logout</span>
+                </a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<!-- Staff JavaScript Fragment -->
+<div th:fragment="staff-scripts">
+    <script>
+        // Mobile menu toggle
+        document.querySelector('.menu-toggle').addEventListener('click', function() {
+            document.querySelector('.sidebar').classList.toggle('show');
+        });
+
+
+        // Sidebar collapse toggle (desktop)
+        const collapseBtn = document.getElementById('sidebarCollapseBtn');
+        if (collapseBtn) {
+            collapseBtn.addEventListener('click', function() {
+                const sidebar = document.querySelector('.sidebar');
+                const main = document.querySelector('.main-content');
+                sidebar.classList.toggle('collapsed');
+                main.classList.toggle('collapsed');
+                // flip icon
+                const icon = this.querySelector('i');
+                if (icon) {
+                    icon.classList.toggle('fa-angles-left');
+                    icon.classList.toggle('fa-angles-right');
+                }
+            });
+        }
+
+
+        // Submenu toggle
+        document.querySelectorAll('.nav-link[data-toggle="submenu"]').forEach(function(link) {
+            link.addEventListener('click', function(e) {
+                e.preventDefault();
+                const targetId = this.getAttribute('data-target');
+                const submenu = document.getElementById(targetId);
+                const chevron = this.querySelector('.fa-chevron-down');
+               
+                if (submenu) {
+                    submenu.classList.toggle('show');
+                   
+                    if (chevron) {
+                        chevron.style.transform = submenu.classList.contains('show') ? 'rotate(180deg)' : 'rotate(0deg)';
+                    }
+                }
+            });
+        });
+
+
+        // Auto-expand active submenu and set active states
+        document.addEventListener('DOMContentLoaded', function() {
+            const currentPath = window.location.pathname;
+           
+            // Set active states for navigation links
+            document.querySelectorAll('.nav-submenu-item').forEach(function(link) {
+                if (link.getAttribute('href') && currentPath.includes(link.getAttribute('href'))) {
+                    link.classList.add('active');
+                   
+                    // Auto-expand parent submenu
+                    const submenu = link.closest('.nav-submenu');
+                    const navLink = submenu.previousElementSibling;
+                    const chevron = navLink.querySelector('.fa-chevron-down');
+                   
+                    if (submenu) {
+                        submenu.classList.add('show');
+                    }
+                   
+                    if (chevron) {
+                        chevron.style.transform = 'rotate(180deg)';
+                    }
+                }
+            });
+           
+            // Set active state for main nav links
+            document.querySelectorAll('.nav-link').forEach(function(link) {
+                if (link.getAttribute('href') && currentPath.includes(link.getAttribute('href'))) {
+                    link.classList.add('active');
+                }
+            });
+
+
+            // When collapsed, clicking icons should navigate even if link is a submenu toggler
+            const sidebar = document.querySelector('.sidebar');
+            document.querySelectorAll('.nav-item > .nav-link').forEach(function(navLink) {
+                navLink.addEventListener('click', function(e) {
+                    if (sidebar.classList.contains('collapsed')) {
+                        const href = this.getAttribute('href');
+                        if (href && href !== '#') {
+                            window.location.href = href;
+                        }
+                    }
+                });
+            });
+        });
+    </script>
+</div>
+
+
+</body>
+</html>


### PR DESCRIPTION
- Added shared Thymeleaf fragments for header, footer, and staff sidebar
- Implemented consistent layout structure for staff dashboard pages
- Created README-staff-sidebar.md documenting i18n keys and sidebar sections
- Added i18n resource entries for staff navigation (products, services, promotions, providers, profile)
- Improved template reusability and maintainability across staff pages