### PR TITLE
feat: add staff service management templates and styles

### DIFF
--- a/backend/SLLBackend/src/main/resources/static/css/staff-service-create.css
+++ b/backend/SLLBackend/src/main/resources/static/css/staff-service-create.css
@@ -5,17 +5,20 @@
   box-sizing: border-box;
 }
 
+
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background-color: #f8f9fa;
   color: #333;
 }
 
+
 /* Layout */
 .d-flex {
   display: flex;
   min-height: 100vh;
 }
+
 
 /* Sidebar */
 .sidebar {
@@ -25,6 +28,7 @@ body {
   flex-shrink: 0;
 }
 
+
 .sidebar-header {
   padding: 20px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -33,24 +37,29 @@ body {
   justify-content: space-between;
 }
 
+
 .logo h4 {
   color: white;
   font-weight: bold;
   margin: 0;
 }
 
+
 .menu-toggle {
   color: white;
   cursor: pointer;
 }
 
+
 .sidebar-nav {
   padding: 20px 0;
 }
 
+
 .nav-item {
   margin-bottom: 5px;
 }
+
 
 .nav-link {
   display: flex;
@@ -62,27 +71,33 @@ body {
   transition: background-color 0.3s;
 }
 
+
 .nav-item.active .nav-link {
   background-color: rgba(255, 255, 255, 0.1);
 }
 
+
 .nav-link:hover {
   background-color: rgba(255, 255, 255, 0.05);
 }
+
 
 .nav-link i {
   margin-right: 10px;
   width: 20px;
 }
 
+
 .nav-link span {
   flex: 1;
 }
+
 
 .nav-submenu {
   background-color: rgba(0, 0, 0, 0.1);
   padding-left: 20px;
 }
+
 
 .nav-sublink {
   display: block;
@@ -93,9 +108,11 @@ body {
   transition: color 0.3s;
 }
 
+
 .nav-sublink:hover {
   color: white;
 }
+
 
 /* Main Content */
 .main-content {
@@ -104,6 +121,7 @@ body {
   flex-direction: column;
   background-color: white;
 }
+
 
 .header {
   background-color: #f8f9fa;
@@ -114,16 +132,19 @@ body {
   align-items: center;
 }
 
+
 .header-left {
   display: flex;
   align-items: center;
 }
+
 
 .header-right {
   display: flex;
   align-items: center;
   gap: 15px;
 }
+
 
 .user-info {
   display: flex;
@@ -132,9 +153,11 @@ body {
   color: #666;
 }
 
+
 .user-info i {
   font-size: 18px;
 }
+
 
 .btn-secondary {
   background-color: #6c757d;
@@ -149,9 +172,11 @@ body {
   gap: 5px;
 }
 
+
 .btn-secondary:hover {
   background-color: #545b62;
 }
+
 
 /* Content */
 .content {
@@ -159,12 +184,14 @@ body {
   flex: 1;
 }
 
+
 .page-title {
   font-size: 28px;
   font-weight: bold;
   color: #333;
   margin-bottom: 30px;
 }
+
 
 /* Form Container */
 .form-container {
@@ -176,13 +203,16 @@ body {
   margin: 0 auto;
 }
 
+
 .service-form {
   padding: 40px;
 }
 
+
 .form-group {
   margin-bottom: 25px;
 }
+
 
 .form-group label {
   display: block;
@@ -191,6 +221,7 @@ body {
   color: #333;
   font-size: 14px;
 }
+
 
 .form-group input,
 .form-group textarea,
@@ -204,6 +235,7 @@ body {
   background-color: white;
 }
 
+
 .form-group input:focus,
 .form-group textarea:focus,
 .form-group select:focus {
@@ -212,18 +244,22 @@ body {
   box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.1);
 }
 
+
 .form-group textarea {
   resize: vertical;
   min-height: 100px;
 }
 
+
 .form-group select {
   cursor: pointer;
 }
 
+
 .form-group select option {
   padding: 10px;
 }
+
 
 /* Checkbox Styling */
 .checkbox-label {
@@ -234,11 +270,13 @@ body {
   color: #333;
 }
 
+
 .checkbox-label input[type="checkbox"] {
   width: auto;
   margin-right: 10px;
   transform: scale(1.2);
 }
+
 
 /* Error Messages */
 .error-message {
@@ -248,15 +286,18 @@ body {
   display: none;
 }
 
+
 .form-group.error input,
 .form-group.error textarea,
 .form-group.error select {
   border-color: #dc3545;
 }
 
+
 .form-group.error .error-message {
   display: block;
 }
+
 
 /* Form Actions */
 .form-actions {
@@ -266,6 +307,7 @@ body {
   padding-top: 30px;
   border-top: 1px solid #e9ecef;
 }
+
 
 .btn {
   padding: 10px 20px;
@@ -280,15 +322,18 @@ body {
   border: none;
 }
 
+
 .btn-primary {
   background-color: #007bff;
   color: white;
 }
 
+
 .btn-primary:hover {
   background-color: #0056b3;
   transform: translateY(-1px);
 }
+
 
 .btn-outline-primary {
   background-color: transparent;
@@ -296,10 +341,12 @@ body {
   border: 2px solid #007bff;
 }
 
+
 .btn-outline-primary:hover {
   background-color: #007bff;
   color: white;
 }
+
 
 /* Modal Styling */
 .modal-content {
@@ -307,15 +354,18 @@ body {
   border: none;
 }
 
+
 .modal-header {
   border-bottom: 1px solid #e9ecef;
   padding: 20px;
 }
 
+
 .modal-body {
   padding: 30px 20px;
   text-align: center;
 }
+
 
 .success-icon,
 .error-icon {
@@ -323,53 +373,58 @@ body {
   margin-bottom: 15px;
 }
 
+
 .success-icon {
   color: #28a745;
 }
 
+
 .error-icon {
   color: #dc3545;
 }
+
 
 .modal-footer {
   border-top: 1px solid #e9ecef;
   padding: 20px;
 }
 
+
 /* Responsive */
 @media (max-width: 768px) {
   .sidebar {
     width: 200px;
   }
-  
+
   .content {
     padding: 20px;
   }
-  
+
   .form-row {
     flex-direction: column;
     gap: 0;
   }
-  
+
   .form-actions {
     flex-direction: column;
   }
-  
+
   .btn {
     width: 100%;
     justify-content: center;
   }
-  
+
   .header {
     flex-direction: column;
     gap: 15px;
     align-items: flex-start;
   }
-  
+
   .header-right {
     align-self: flex-end;
   }
 }
+
 
 @media (max-width: 576px) {
   .sidebar {
@@ -379,19 +434,19 @@ body {
     transform: translateX(-100%);
     transition: transform 0.3s;
   }
-  
+
   .sidebar.open {
     transform: translateX(0);
   }
-  
+
   .main-content {
     margin-left: 0;
   }
-  
+
   .content {
     padding: 15px;
   }
-  
+
   .service-form {
     padding: 20px;
   }

--- a/backend/SLLBackend/src/main/resources/static/css/staff-service-edit.css
+++ b/backend/SLLBackend/src/main/resources/static/css/staff-service-edit.css
@@ -1,15 +1,34 @@
 /* Reset and base styles */
+:root {
+  --primary-color: #6366f1;
+  --primary-hover: #4f46e5;
+  --secondary-color: #6b7280;
+  --success-color: #10b981;
+  --danger-color: #ef4444;
+  --warning-color: #f59e0b;
+  --info-color: #3b82f6;
+  --light-color: #f8fafc;
+  --dark-color: #1f2937;
+  --border-color: #e5e7eb;
+  --text-muted: #6b7280;
+  --sidebar-width: 280px;
+}
+
+
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
+
 body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f8f9fa;
-  color: #333;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background-color: #f8fafc;
+  color: var(--dark-color);
+  line-height: 1.6;
 }
+
 
 /* Layout */
 .d-flex {
@@ -17,472 +36,188 @@ body {
   min-height: 100vh;
 }
 
-/* Sidebar */
-.sidebar {
-  width: 250px;
-  background-color: #1e3a8a;
-  color: white;
-  flex-shrink: 0;
-}
-
-.sidebar-header {
-  padding: 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.logo h4 {
-  color: white;
-  font-weight: bold;
-  margin: 0;
-}
-
-.menu-toggle {
-  color: white;
-  cursor: pointer;
-}
-
-.sidebar-nav {
-  padding: 20px 0;
-}
-
-.nav-item {
-  margin-bottom: 5px;
-}
-
-.nav-link {
-  display: flex;
-  align-items: center;
-  padding: 12px 20px;
-  color: white;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background-color 0.3s;
-}
-
-.nav-item.active .nav-link {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-.nav-link:hover {
-  background-color: rgba(255, 255, 255, 0.05);
-}
-
-.nav-link i {
-  margin-right: 10px;
-  width: 20px;
-}
-
-.nav-link span {
-  flex: 1;
-}
-
-.nav-submenu {
-  background-color: rgba(0, 0, 0, 0.1);
-  padding-left: 20px;
-}
-
-.nav-sublink {
-  display: block;
-  padding: 8px 20px;
-  color: rgba(255, 255, 255, 0.8);
-  text-decoration: none;
-  font-size: 14px;
-  transition: color 0.3s;
-}
-
-.nav-sublink:hover {
-  color: white;
-}
-
-/* Main Content */
-.main-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  background-color: white;
-}
-
-.header {
-  background-color: #f8f9fa;
-  padding: 15px 30px;
-  border-bottom: 1px solid #e9ecef;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.header-left {
-  display: flex;
-  align-items: center;
-}
-
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 15px;
-}
-
-.user-info {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: #666;
-}
-
-.user-info i {
-  font-size: 18px;
-}
-
-.btn-secondary {
-  background-color: #6c757d;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 4px;
-  color: white;
-  font-size: 14px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-
-.btn-secondary:hover {
-  background-color: #545b62;
-}
-
 /* Content */
 .content {
-  padding: 30px;
   flex: 1;
+  padding: 2rem;
 }
+
 
 .page-title {
-  font-size: 28px;
-  font-weight: bold;
-  color: #333;
-  margin-bottom: 10px;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--dark-color);
+  margin-bottom: 0.5rem;
 }
+
 
 .service-info {
-  color: #6c757d;
-  font-size: 14px;
-  margin-bottom: 30px;
-  padding: 10px 15px;
-  background-color: #f8f9fa;
-  border-radius: 6px;
-  border-left: 4px solid #007bff;
+  color: var(--text-muted);
+  margin-bottom: 2rem;
 }
 
-.service-info span {
-  font-weight: 500;
-  color: #007bff;
-}
 
 /* Form Container */
 .form-container {
   background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
-  max-width: 600px;
-  margin: 0 auto;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  border: 1px solid var(--border-color);
 }
 
-.service-form {
-  padding: 40px;
-}
 
 .form-group {
-  margin-bottom: 25px;
+  margin-bottom: 1.5rem;
 }
 
-.form-group label {
+
+.form-label {
   display: block;
-  margin-bottom: 8px;
   font-weight: 500;
-  color: #333;
-  font-size: 14px;
+  margin-bottom: 0.5rem;
+  color: var(--dark-color);
 }
 
-.form-group input,
-.form-group textarea,
-.form-group select {
+
+.form-label.required::after {
+  content: " *";
+  color: var(--danger-color);
+}
+
+
+.form-control {
   width: 100%;
-  padding: 12px 15px;
-  border: 2px solid #e9ecef;
-  border-radius: 6px;
-  font-size: 14px;
-  transition: border-color 0.3s, box-shadow 0.3s;
-  background-color: white;
-}
-
-.form-group input:focus,
-.form-group textarea:focus,
-.form-group select:focus {
-  outline: none;
-  border-color: #007bff;
-  box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.1);
-}
-
-.form-group textarea {
-  resize: vertical;
-  min-height: 100px;
-}
-
-.form-group select {
-  cursor: pointer;
-}
-
-.form-group select option {
-  padding: 10px;
-}
-
-/* Checkbox Styling */
-.checkbox-label {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  font-weight: 500;
-  color: #333;
-}
-
-.checkbox-label input[type="checkbox"] {
-  width: auto;
-  margin-right: 10px;
-  transform: scale(1.2);
-}
-
-/* Error Messages */
-.error-message {
-  color: #dc3545;
-  font-size: 12px;
-  margin-top: 5px;
-  display: none;
-}
-
-.form-group input.error,
-.form-group textarea.error,
-.form-group select.error {
-  border-color: #dc3545;
-}
-
-.form-group input.error:focus,
-.form-group textarea.error:focus,
-.form-group select.error:focus {
-  border-color: #dc3545;
-  box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.1);
-}
-
-/* Form Actions */
-.form-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 15px;
-  padding-top: 30px;
-  border-top: 1px solid #e9ecef;
-}
-
-.btn {
-  padding: 10px 20px;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  transition: all 0.3s;
-  border: none;
-}
-
-.btn-primary {
-  background-color: #007bff;
-  color: white;
-}
-
-.btn-primary:hover {
-  background-color: #0056b3;
-  transform: translateY(-1px);
-}
-
-.btn-outline-primary {
-  background-color: transparent;
-  color: #007bff;
-  border: 2px solid #007bff;
-}
-
-.btn-outline-primary:hover {
-  background-color: #007bff;
-  color: white;
-}
-
-/* Modal Styling */
-.modal-content {
+  padding: 0.75rem;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
-  border: none;
-}
-
-.modal-header {
-  border-bottom: 1px solid #e9ecef;
-  padding: 20px;
-}
-
-.modal-body {
-  padding: 30px 20px;
-  text-align: center;
-}
-
-.success-icon,
-.error-icon {
-  font-size: 48px;
-  margin-bottom: 15px;
-}
-
-.success-icon {
-  color: #28a745;
-}
-
-.error-icon {
-  color: #dc3545;
-}
-
-.modal-footer {
-  border-top: 1px solid #e9ecef;
-  padding: 20px;
-}
-
-/* Loading States */
-.btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.btn:disabled:hover {
-  transform: none;
-}
-
-/* Animation for form elements */
-.form-group input,
-.form-group textarea,
-.form-group select {
+  font-size: 0.95rem;
   transition: all 0.3s ease;
 }
 
-.form-group input:focus,
-.form-group textarea:focus,
-.form-group select:focus {
+
+.form-control:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
+
+.form-control.invalid {
+  border-color: var(--danger-color);
+}
+
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+
+.checkbox-label input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+}
+
+
+/* Error Messages */
+.error-message {
+  color: var(--danger-color);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+  display: none;
+}
+/* Form Actions */
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-color);
+}
+
+
+.btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+
+.btn-primary {
+  background: var(--primary-color);
+  color: white;
+}
+
+
+.btn-primary:hover {
+  background: var(--primary-hover);
+  transform: translateY(-1px);
+}
+.btn-secondary {
+  background: var(--secondary-color);
+  color: white;
+}
+
+.btn-secondary:hover {
+  background: #4b5563;
   transform: translateY(-1px);
 }
 
-/* Success state for form fields */
-.form-group input.success,
-.form-group textarea.success,
-.form-group select.success {
-  border-color: #28a745;
+/* Alert Styles */
+.alert {
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  border: 1px solid;
 }
 
-.form-group input.success:focus,
-.form-group textarea.success:focus,
-.form-group select.success:focus {
-  box-shadow: 0 0 0 3px rgba(40, 167, 69, 0.1);
+.alert-error {
+  background-color: #fef2f2;
+  border-color: #fecaca;
+  color: #991b1b;
 }
 
 /* Responsive */
 @media (max-width: 768px) {
   .sidebar {
-    width: 200px;
-  }
-  
-  .content {
-    padding: 20px;
-  }
-  
-  .form-row {
-    flex-direction: column;
-    gap: 0;
-  }
-  
-  .form-actions {
-    flex-direction: column;
-  }
-  
-  .btn {
-    width: 100%;
-    justify-content: center;
-  }
-  
-  .header {
-    flex-direction: column;
-    gap: 15px;
-    align-items: flex-start;
-  }
-  
-  .header-right {
-    align-self: flex-end;
-  }
-  
-  .service-info {
-    font-size: 13px;
-    padding: 8px 12px;
-  }
-}
-
-@media (max-width: 576px) {
-  .sidebar {
-    width: 100%;
-    position: fixed;
-    z-index: 1000;
     transform: translateX(-100%);
-    transition: transform 0.3s;
   }
-  
-  .sidebar.open {
+
+  .sidebar.show {
     transform: translateX(0);
   }
-  
+
   .main-content {
     margin-left: 0;
   }
-  
-  .content {
-    padding: 15px;
-  }
-  
-  .service-form {
-    padding: 20px;
-  }
-  
-  .page-title {
-    font-size: 24px;
-  }
-  
-  .service-info {
-    font-size: 12px;
-    padding: 6px 10px;
-  }
-}
 
-/* Print styles */
-@media print {
-  .sidebar,
-  .header,
-  .form-actions {
-    display: none;
+  .menu-toggle {
+    display: block;
   }
-  
-  .main-content {
-    margin: 0;
-  }
-  
+
+
   .content {
-    padding: 0;
+    padding: 1rem;
   }
-  
+
+
   .form-container {
-    box-shadow: none;
-    border: 1px solid #ddd;
+    padding: 1.5rem;
+  }
+
+  .form-actions {
+    flex-direction: column;
   }
 }

--- a/backend/SLLBackend/src/main/resources/static/css/staff-service-list.css
+++ b/backend/SLLBackend/src/main/resources/static/css/staff-service-list.css
@@ -5,11 +5,13 @@
   box-sizing: border-box;
 }
 
+
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background-color: #f8f9fa;
   color: #333;
 }
+
 
 /* Layout */
 .d-flex {
@@ -17,136 +19,8 @@ body {
   min-height: 100vh;
 }
 
-/* Sidebar */
-.sidebar {
-  width: 250px;
-  background-color: #1e3a8a;
-  color: white;
-  flex-shrink: 0;
-}
 
-.sidebar-header {
-  padding: 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
 
-.logo h4 {
-  color: white;
-  font-weight: bold;
-  margin: 0;
-}
-
-.menu-toggle {
-  color: white;
-  cursor: pointer;
-}
-
-.sidebar-nav {
-  padding: 20px 0;
-}
-
-.nav-item {
-  margin-bottom: 5px;
-}
-
-.nav-link {
-  display: flex;
-  align-items: center;
-  padding: 12px 20px;
-  color: white;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background-color 0.3s;
-}
-
-.nav-item.active .nav-link {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-.nav-link:hover {
-  background-color: rgba(255, 255, 255, 0.05);
-}
-
-.nav-link i {
-  margin-right: 10px;
-  width: 20px;
-}
-
-.nav-link span {
-  flex: 1;
-}
-
-.nav-submenu {
-  background-color: rgba(0, 0, 0, 0.1);
-  padding-left: 20px;
-}
-
-.nav-sublink {
-  display: block;
-  padding: 8px 20px;
-  color: rgba(255, 255, 255, 0.8);
-  text-decoration: none;
-  font-size: 14px;
-  transition: color 0.3s;
-}
-
-.nav-sublink:hover {
-  color: white;
-}
-
-/* Main Content */
-.main-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  background-color: white;
-}
-
-.header {
-  background-color: #f8f9fa;
-  padding: 15px 30px;
-  border-bottom: 1px solid #e9ecef;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
-
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 15px;
-}
-
-.user-info {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: #666;
-}
-
-.user-info i {
-  font-size: 18px;
-}
-
-.btn-primary {
-  background-color: #007bff;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 4px;
-  color: white;
-  font-size: 14px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-
-.btn-primary:hover {
-  background-color: #0056b3;
-}
 
 /* Content */
 .content {
@@ -154,12 +28,14 @@ body {
   flex: 1;
 }
 
+
 .page-title {
   font-size: 28px;
   font-weight: bold;
   color: #333;
   margin-bottom: 20px;
 }
+
 
 /* Search and Filter Section */
 .search-section {
@@ -169,17 +45,37 @@ body {
   margin-bottom: 20px;
 }
 
+
 .search-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
+  display: flex;
+  flex-wrap: wrap;
   gap: 20px;
   margin-bottom: 15px;
 }
 
+
 .search-group {
   display: flex;
   flex-direction: column;
+  min-width: 240px;
 }
+
+
+/* Make category checkboxes display horizontally with wrapping */
+.category-group .checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 24px;
+}
+
+
+.category-group .checkbox-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 160px;
+}
+
 
 .search-group label {
   margin-bottom: 5px;
@@ -187,6 +83,7 @@ body {
   color: #333;
   font-size: 14px;
 }
+
 
 .search-group input,
 .search-group select {
@@ -197,6 +94,7 @@ body {
   background-color: white;
 }
 
+
 .search-group input:focus,
 .search-group select:focus {
   outline: none;
@@ -204,12 +102,14 @@ body {
   box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.1);
 }
 
+
 .radio-group {
   display: flex;
   gap: 15px;
   align-items: center;
   flex-wrap: wrap;
 }
+
 
 .radio-group label {
   display: flex;
@@ -220,42 +120,16 @@ body {
   font-size: 14px;
 }
 
+
 .radio-group input[type="radio"] {
   margin: 0;
 }
+
 
 .button-group {
   display: flex;
   gap: 10px;
   margin-top: 15px;
-}
-
-.btn-search {
-  background-color: #007bff;
-  color: white;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-}
-
-.btn-search:hover {
-  background-color: #0056b3;
-}
-
-.btn-reset {
-  background-color: #6c757d;
-  color: white;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-}
-
-.btn-reset:hover {
-  background-color: #545b62;
 }
 
 /* Table */
@@ -267,10 +141,12 @@ body {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+
 .data-table {
   width: 100%;
   border-collapse: collapse;
 }
+
 
 .data-table th {
   background-color: #f8f9fa;
@@ -283,6 +159,7 @@ body {
   white-space: nowrap;
 }
 
+
 .data-table td {
   padding: 12px 15px;
   border-bottom: 1px solid #f1f3f4;
@@ -290,13 +167,16 @@ body {
   vertical-align: middle;
 }
 
+
 .data-table tr:nth-child(even) {
   background-color: #f8f9fa;
 }
 
+
 .data-table tr:hover {
   background-color: #e9ecef;
 }
+
 
 /* Service specific styling */
 .service-type-badge {
@@ -308,15 +188,18 @@ body {
   text-transform: uppercase;
 }
 
+
 .service-type-single {
   background-color: #e3f2fd;
   color: #1976d2;
 }
 
+
 .service-type-combo {
   background-color: #f3e5f5;
   color: #7b1fa2;
 }
+
 
 .duration-badge {
   display: inline-block;
@@ -328,10 +211,12 @@ body {
   font-weight: 500;
 }
 
+
 .price-value {
   font-weight: 600;
   color: #2e7d32;
 }
+
 
 .status-badge {
   display: inline-block;
@@ -341,15 +226,18 @@ body {
   font-weight: 500;
 }
 
+
 .status-active {
   background-color: #d4edda;
   color: #155724;
 }
 
+
 .status-inactive {
   background-color: #f8d7da;
   color: #721c24;
 }
+
 
 /* Action buttons */
 .action-buttons {
@@ -357,6 +245,7 @@ body {
   gap: 8px;
   align-items: center;
 }
+
 
 .btn-edit {
   background-color: #007bff;
@@ -372,11 +261,13 @@ body {
   gap: 4px;
 }
 
+
 .btn-edit:hover {
   background-color: #0056b3;
   color: white;
   text-decoration: none;
 }
+
 
 .btn-delete {
   background-color: #dc3545;
@@ -391,9 +282,11 @@ body {
   gap: 4px;
 }
 
+
 .btn-delete:hover {
   background-color: #c82333;
 }
+
 
 /* Modal Styling */
 .modal-content {
@@ -401,15 +294,18 @@ body {
   border: none;
 }
 
+
 .modal-header {
   border-bottom: 1px solid #e9ecef;
   padding: 20px;
 }
 
+
 .modal-body {
   padding: 30px 20px;
   text-align: center;
 }
+
 
 .success-icon,
 .error-icon {
@@ -417,18 +313,22 @@ body {
   margin-bottom: 15px;
 }
 
+
 .success-icon {
   color: #28a745;
 }
+
 
 .error-icon {
   color: #dc3545;
 }
 
+
 .modal-footer {
   border-top: 1px solid #e9ecef;
   padding: 20px;
 }
+
 
 /* Responsive */
 @media (max-width: 1200px) {
@@ -438,40 +338,37 @@ body {
   }
 }
 
+
 @media (max-width: 768px) {
-  .sidebar {
-    width: 200px;
-  }
-  
   .content {
     padding: 20px;
   }
-  
+
   .search-row {
     grid-template-columns: 1fr;
     gap: 15px;
   }
-  
+
   .radio-group {
     flex-direction: column;
     align-items: flex-start;
     gap: 10px;
   }
-  
+
   .data-table {
     font-size: 12px;
   }
-  
+
   .data-table th,
   .data-table td {
     padding: 8px 10px;
   }
-  
+
   .action-buttons {
     flex-direction: column;
     gap: 4px;
   }
-  
+
   .btn-edit,
   .btn-delete {
     font-size: 11px;
@@ -479,31 +376,20 @@ body {
   }
 }
 
+
 @media (max-width: 576px) {
-  .sidebar {
-    width: 100%;
-    position: fixed;
-    z-index: 1000;
-    transform: translateX(-100%);
-    transition: transform 0.3s;
-  }
-  
-  .sidebar.open {
-    transform: translateX(0);
-  }
-  
   .main-content {
     margin-left: 0;
   }
-  
+
   .content {
     padding: 15px;
   }
-  
+
   .table-container {
     overflow-x: auto;
   }
-  
+
   .data-table {
     min-width: 600px;
   }

--- a/backend/SLLBackend/src/main/resources/templates/staff-service-create.html
+++ b/backend/SLLBackend/src/main/resources/templates/staff-service-create.html
@@ -1,165 +1,162 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}">
 <head>
     <meta charset="UTF-8" />
-    <title>Staff - Create Service</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title th:text="#{staff.services.create.title} + ' | ' + #{app.name}">Create Service | Salon Loan Loan</title>
+   
+    <!-- Bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" />
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+    <!-- Your CSS -->
+    <link rel="stylesheet" th:href="@{/css/staff-service-create.css}">
+    <!-- Staff Sidebar CSS -->
+    <link rel="stylesheet" th:href="@{/css/staff-sidebar.css}">
     <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 20px;
-            max-width: 800px;
-        }
-        h1 {
-            color: #333;
-        }
-        .form-group {
-            margin-bottom: 20px;
-        }
-        .form-group label {
-            display: block;
-            font-weight: bold;
-            margin-bottom: 5px;
-        }
-        .form-group input,
-        .form-group select,
-        .form-group textarea {
-            width: 100%;
-            padding: 8px;
-            border: 1px solid #ddd;
-            border-radius: 4px;
-            box-sizing: border-box;
-        }
-        .form-group textarea {
-            resize: vertical;
-            min-height: 100px;
-        }
-        .form-group .error {
-            color: #dc3545;
-            font-size: 0.875em;
-            margin-top: 5px;
-            display: none;
-        }
-        .form-group input.invalid,
-        .form-group select.invalid {
-            border-color: #dc3545;
-        }
-        .checkbox-group {
-            display: flex;
-            align-items: center;
-        }
-        .checkbox-group input {
-            width: auto;
-            margin-right: 8px;
-        }
-        .button-group {
-            margin-top: 30px;
-            display: flex;
-            gap: 10px;
-        }
-        .btn {
-            padding: 10px 20px;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 16px;
-        }
-        .btn-primary {
-            background: #007bff;
-            color: white;
-        }
-        .btn-primary:hover {
-            background: #0056b3;
-        }
-        .btn-secondary {
-            background: #6c757d;
-            color: white;
-        }
-        .btn-secondary:hover {
-            background: #545b62;
-        }
-        .alert {
-            padding: 12px;
-            margin-bottom: 20px;
-            border-radius: 4px;
-        }
-        .alert-error {
-            background: #f8d7da;
-            color: #721c24;
-            border: 1px solid #f5c6cb;
-        }
-        .required::after {
+        .form-label.required::after {
             content: " *";
             color: #dc3545;
         }
     </style>
 </head>
 <body>
-    <h1>Create New Service</h1>
+    <div class="d-flex">
+        <!-- Sidebar Fragment -->
+        <div th:replace="fragments/staff-sidebar :: staff-sidebar"></div>
 
-    <!-- Error Messages -->
-    <div th:if="${errorMessage}" class="alert alert-error" th:text="${errorMessage}"></div>
 
-    <form id="createServiceForm" method="post" action="/staff/service/create">
-        <div class="form-group">
-            <label for="serviceName" class="required">Service Name</label>
-            <input type="text" id="serviceName" name="serviceName" required>
-            <div class="error" id="serviceNameError">Service name is required</div>
-        </div>
+        <!-- Main Content -->
+        <div class="main-content">
+            <!-- Header Fragment with Add Service Button -->
+            <div th:replace="fragments/staff-sidebar :: staff-header-with-add-service"></div>
 
-        <div class="form-group">
-            <label for="serviceCategoryId" class="required">Service Category</label>
-            <select id="serviceCategoryId" name="serviceCategoryId" required>
-                <option value="">-- Select Category --</option>
-                <option th:each="category : ${categories}" 
-                        th:value="${category.id}" 
-                        th:text="${category.name}">Category</option>
-            </select>
-            <div class="error" id="serviceCategoryIdError">Service category is required</div>
-        </div>
 
-        <div class="form-group">
-            <label for="serviceType" class="required">Service Type</label>
-            <select id="serviceType" name="serviceType" required>
-                <option value="">-- Select Type --</option>
-                <option value="SINGLE">Single</option>
-                <option value="COMBO">Combo</option>
-            </select>
-            <div class="error" id="serviceTypeError">Service type is required</div>
-        </div>
+            <!-- Content -->
+            <div class="content">
+                <h1 class="page-title" th:text="#{staff.services.create.title}">Create New Service</h1>
 
-        <div class="form-group">
-            <label for="servicePrice" class="required">Service Price (VND)</label>
-            <input type="number" id="servicePrice" name="servicePrice" min="0" required>
-            <div class="error" id="servicePriceError">Service price is required and must be a positive number</div>
-        </div>
 
-        <div class="form-group">
-            <label for="durationMinutes" class="required">Duration (minutes)</label>
-            <input type="number" id="durationMinutes" name="durationMinutes" min="1" max="32767" required>
-            <div class="error" id="durationMinutesError">Duration is required and must be between 1 and 32767 minutes</div>
-        </div>
+                <!-- Error Messages -->
+                <div th:if="${errorMessage}" class="alert alert-danger alert-dismissible fade show" role="alert">
+                    <i class="fa-solid fa-exclamation-circle me-2"></i>
+                    <span th:text="${errorMessage}">Error message</span>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                </div>
 
-        <div class="form-group">
-            <label for="serviceDescription">Service Description</label>
-            <textarea id="serviceDescription" name="serviceDescription"></textarea>
-        </div>
 
-        <div class="form-group">
-            <div class="checkbox-group">
-                <input type="checkbox" id="activeStatus" name="activeStatus" value="true">
-                <label for="activeStatus">Active Status</label>
+                <!-- Create Service Form -->
+                <div class="form-container">
+                    <form id="createServiceForm" method="post" th:action="@{/staff/service/create}" class="service-form">
+                        <div class="form-group">
+                            <label for="serviceName" class="form-label required">
+                                <i class="fas fa-tag me-1"></i>
+                                <span th:text="#{staff.services.form.name}">Service Name</span>
+                            </label>
+                            <input type="text" id="serviceName" name="serviceName"
+                                   th:placeholder="#{staff.services.form.name.placeholder}" required>
+                            <div class="error-message" id="serviceNameError" th:text="#{staff.services.form.name.error}">Service name is required</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="serviceCategoryId" class="form-label required">
+                                <i class="fas fa-list me-1"></i>
+                                <span th:text="#{staff.services.form.category}">Service Category</span>
+                            </label>
+                            <select id="serviceCategoryId" name="serviceCategoryId" required>
+                                <option value="" th:text="#{staff.services.form.category.select}">-- Select Category --</option>
+                                <option th:each="category : ${categories}"
+                                        th:value="${category.id}"
+                                        th:text="${category.name}">Category</option>
+                            </select>
+                            <div class="error-message" id="serviceCategoryIdError" th:text="#{staff.services.form.category.error}">Service category is required</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="serviceType" class="form-label required">
+                                <i class="fas fa-cog me-1"></i>
+                                <span th:text="#{staff.services.form.type}">Service Type</span>
+                            </label>
+                            <select id="serviceType" name="serviceType" required>
+                                <option value="" th:text="#{staff.services.form.type.select}">-- Select Type --</option>
+                                <option value="SINGLE" th:text="#{staff.services.form.type.single}">Single</option>
+                                <option value="COMBO" th:text="#{staff.services.form.type.combo}">Combo</option>
+                            </select>
+                            <div class="error-message" id="serviceTypeError" th:text="#{staff.services.form.type.error}">Service type is required</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="servicePrice" class="form-label required">
+                                <i class="fas fa-dollar-sign me-1"></i>
+                                <span th:text="#{staff.services.form.price}">Service Price (VND)</span>
+                            </label>
+                            <input type="number" id="servicePrice" name="servicePrice" min="0" step="1000"
+                                   th:placeholder="#{staff.services.form.price.placeholder}" required>
+                            <div class="error-message" id="servicePriceError" th:text="#{staff.services.form.price.error}">Service price is required and must be a positive number</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="durationMinutes" class="form-label required">
+                                <i class="fas fa-clock me-1"></i>
+                                <span th:text="#{staff.services.form.duration}">Duration (minutes)</span>
+                            </label>
+                            <input type="number" id="durationMinutes" name="durationMinutes" min="1" max="480"
+                                   th:placeholder="#{staff.services.form.duration.placeholder}" required>
+                            <div class="error-message" id="durationMinutesError" th:text="#{staff.services.form.duration.error}">Duration is required and must be between 1 and 480 minutes</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="serviceDescription" class="form-label">
+                                <i class="fas fa-align-left me-1"></i>
+                                <span th:text="#{staff.services.form.description}">Service Description</span>
+                            </label>
+                            <textarea id="serviceDescription" name="serviceDescription" rows="4"
+                                      th:placeholder="#{staff.services.form.description.placeholder}"></textarea>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" id="activeStatus" name="activeStatus" value="true">
+                                <span th:text="#{staff.services.form.status}">Active Status</span>
+                            </label>
+                        </div>
+
+
+                        <div class="form-actions">
+                            <button type="button" class="btn btn-secondary" th:onclick="'window.location.href=\'' + @{/staff/service/list} + '\''">
+                                <i class="fas fa-times me-2"></i>
+                                <span th:text="#{btn.cancel}">Cancel</span>
+                            </button>
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-plus me-2"></i>
+                                <span th:text="#{btn.create}">Create Service</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
+    </div>
 
-        <div class="button-group">
-            <button type="submit" class="btn btn-primary">Create Service</button>
-            <button type="button" class="btn btn-secondary" onclick="window.location.href='/staff/service/list'">Cancel</button>
-        </div>
-    </form>
 
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+   
+    <!-- Staff Scripts Fragment -->
+    <div th:replace="fragments/staff-sidebar :: staff-scripts"></div>
+   
     <script>
         document.getElementById('createServiceForm').addEventListener('submit', function(event) {
             let isValid = true;
+
 
             // Validate service name
             const serviceName = document.getElementById('serviceName');
@@ -173,6 +170,7 @@
                 serviceNameError.style.display = 'none';
             }
 
+
             // Validate service category
             const serviceCategoryId = document.getElementById('serviceCategoryId');
             const serviceCategoryIdError = document.getElementById('serviceCategoryIdError');
@@ -184,6 +182,7 @@
                 serviceCategoryId.classList.remove('invalid');
                 serviceCategoryIdError.style.display = 'none';
             }
+
 
             // Validate service type
             const serviceType = document.getElementById('serviceType');
@@ -197,6 +196,7 @@
                 serviceTypeError.style.display = 'none';
             }
 
+
             // Validate service price
             const servicePrice = document.getElementById('servicePrice');
             const servicePriceError = document.getElementById('servicePriceError');
@@ -208,6 +208,7 @@
                 servicePrice.classList.remove('invalid');
                 servicePriceError.style.display = 'none';
             }
+
 
             // Validate duration minutes
             const durationMinutes = document.getElementById('durationMinutes');
@@ -222,11 +223,13 @@
                 durationMinutesError.style.display = 'none';
             }
 
+
             if (!isValid) {
                 event.preventDefault();
                 alert('Please correct the errors in the form before submitting.');
             }
         });
+
 
         // Real-time validation on input
         document.getElementById('serviceName').addEventListener('input', function() {
@@ -236,12 +239,14 @@
             }
         });
 
+
         document.getElementById('serviceCategoryId').addEventListener('change', function() {
             if (this.value) {
                 this.classList.remove('invalid');
                 document.getElementById('serviceCategoryIdError').style.display = 'none';
             }
         });
+
 
         document.getElementById('serviceType').addEventListener('change', function() {
             if (this.value) {
@@ -250,12 +255,14 @@
             }
         });
 
+
         document.getElementById('servicePrice').addEventListener('input', function() {
             if (this.value && parseInt(this.value) >= 0) {
                 this.classList.remove('invalid');
                 document.getElementById('servicePriceError').style.display = 'none';
             }
         });
+
 
         document.getElementById('durationMinutes').addEventListener('input', function() {
             const duration = parseInt(this.value);

--- a/backend/SLLBackend/src/main/resources/templates/staff-service-edit.html
+++ b/backend/SLLBackend/src/main/resources/templates/staff-service-edit.html
@@ -1,176 +1,159 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}">
 <head>
     <meta charset="UTF-8" />
-    <title>Staff - Edit Service</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 20px;
-            max-width: 800px;
-        }
-        h1 {
-            color: #333;
-        }
-        .form-group {
-            margin-bottom: 20px;
-        }
-        .form-group label {
-            display: block;
-            font-weight: bold;
-            margin-bottom: 5px;
-        }
-        .form-group input,
-        .form-group select,
-        .form-group textarea {
-            width: 100%;
-            padding: 8px;
-            border: 1px solid #ddd;
-            border-radius: 4px;
-            box-sizing: border-box;
-        }
-        .form-group textarea {
-            resize: vertical;
-            min-height: 100px;
-        }
-        .form-group .error {
-            color: #dc3545;
-            font-size: 0.875em;
-            margin-top: 5px;
-            display: none;
-        }
-        .form-group input.invalid,
-        .form-group select.invalid {
-            border-color: #dc3545;
-        }
-        .checkbox-group {
-            display: flex;
-            align-items: center;
-        }
-        .checkbox-group input {
-            width: auto;
-            margin-right: 8px;
-        }
-        .button-group {
-            margin-top: 30px;
-            display: flex;
-            gap: 10px;
-        }
-        .btn {
-            padding: 10px 20px;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 16px;
-        }
-        .btn-primary {
-            background: #007bff;
-            color: white;
-        }
-        .btn-primary:hover {
-            background: #0056b3;
-        }
-        .btn-secondary {
-            background: #6c757d;
-            color: white;
-        }
-        .btn-secondary:hover {
-            background: #545b62;
-        }
-        .alert {
-            padding: 12px;
-            margin-bottom: 20px;
-            border-radius: 4px;
-        }
-        .alert-error {
-            background: #f8d7da;
-            color: #721c24;
-            border: 1px solid #f5c6cb;
-        }
-        .required::after {
-            content: " *";
-            color: #dc3545;
-        }
-        .info-text {
-            color: #6c757d;
-            font-size: 0.875em;
-        }
-    </style>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title th:text="#{staff.services.edit.title} + ' | ' + #{app.name}">Edit Service | Salon Loan Loan</title>
+   
+    <!-- Bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" />
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+    <!-- Your CSS -->
+    <link rel="stylesheet" th:href="@{/css/staff-service-edit.css}">
+    <!-- Staff Sidebar CSS -->
+    <link rel="stylesheet" th:href="@{/css/staff-sidebar.css}">
 </head>
 <body>
-    <h1>Edit Service</h1>
-    <p class="info-text">Service ID: <span th:text="${service.id}">1</span></p>
+    <div class="d-flex">
+        <!-- Sidebar Fragment -->
+        <div th:replace="fragments/staff-sidebar :: staff-sidebar"></div>
 
-    <!-- Error Messages -->
-    <div th:if="${errorMessage}" class="alert alert-error" th:text="${errorMessage}"></div>
 
-    <form id="editServiceForm" method="post" th:action="@{/staff/service/edit/{id}(id=${service.id})}">
-        <div class="form-group">
-            <label for="serviceName" class="required">Service Name</label>
-            <input type="text" id="serviceName" name="serviceName" 
-                   th:value="${service.serviceName}" required>
-            <div class="error" id="serviceNameError">Service name is required</div>
-        </div>
+        <!-- Main Content -->
+        <div class="main-content">
+            <!-- Header Fragment with Add Service Button -->
+            <div th:replace="fragments/staff-sidebar :: staff-header-with-add-service"></div>
 
-        <div class="form-group">
-            <label for="serviceCategoryId" class="required">Service Category</label>
-            <select id="serviceCategoryId" name="serviceCategoryId" required>
-                <option value="">-- Select Category --</option>
-                <option th:each="category : ${categories}" 
-                        th:value="${category.id}" 
-                        th:text="${category.name}"
-                        th:selected="${service.serviceCategory.id == category.id}">Category</option>
-            </select>
-            <div class="error" id="serviceCategoryIdError">Service category is required</div>
-        </div>
 
-        <div class="form-group">
-            <label for="serviceType" class="required">Service Type</label>
-            <select id="serviceType" name="serviceType" required>
-                <option value="">-- Select Type --</option>
-                <option value="SINGLE" th:selected="${service.serviceType.name() == 'SINGLE'}">Single</option>
-                <option value="COMBO" th:selected="${service.serviceType.name() == 'COMBO'}">Combo</option>
-            </select>
-            <div class="error" id="serviceTypeError">Service type is required</div>
-        </div>
+            <!-- Content -->
+            <div class="content">
+                <h1 class="page-title" th:text="#{staff.services.edit.title}">Edit Service</h1>
+                <p class="service-info" th:text="#{staff.services.edit.info} + ': ' + ${service.id}">Service ID: 1</p>
 
-        <div class="form-group">
-            <label for="servicePrice" class="required">Service Price (VND)</label>
-            <input type="number" id="servicePrice" name="servicePrice" min="0" 
-                   th:value="${service.servicePrice}" required>
-            <div class="error" id="servicePriceError">Service price is required and must be a positive number</div>
-        </div>
 
-        <div class="form-group">
-            <label for="durationMinutes" class="required">Duration (minutes)</label>
-            <input type="number" id="durationMinutes" name="durationMinutes" min="1" max="32767" 
-                   th:value="${service.durationMinutes}" required>
-            <div class="error" id="durationMinutesError">Duration is required and must be between 1 and 32767 minutes</div>
-        </div>
+                <!-- Error Messages -->
+                <div th:if="${errorMessage}" class="alert alert-error" th:text="${errorMessage}"></div>
 
-        <div class="form-group">
-            <label for="serviceDescription">Service Description</label>
-            <textarea id="serviceDescription" name="serviceDescription" 
-                      th:text="${service.serviceDescription}"></textarea>
-        </div>
 
-        <div class="form-group">
-            <div class="checkbox-group">
-                <input type="checkbox" id="activeStatus" name="activeStatus" value="true"
-                       th:checked="${service.activeStatus}">
-                <label for="activeStatus">Active Status</label>
+                <!-- Edit Service Form -->
+                <div class="form-container">
+                    <form id="editServiceForm" method="post" th:action="@{/staff/service/edit/{id}(id=${service.id})}">
+                        <div class="form-group">
+                            <label for="serviceName" class="form-label required">
+                                <i class="fas fa-tag me-2"></i>
+                                <span th:text="#{staff.services.form.name}">Service Name</span>
+                            </label>
+                            <input type="text" id="serviceName" name="serviceName" class="form-control"
+                                   th:value="${service.serviceName}"
+                                   th:placeholder="#{staff.services.form.name.placeholder}" required>
+                            <div class="error-message" id="serviceNameError" th:text="#{staff.services.form.name.error}">Service name is required</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="serviceCategoryId" class="form-label required">
+                                <i class="fas fa-folder me-2"></i>
+                                <span th:text="#{staff.services.form.category}">Service Category</span>
+                            </label>
+                            <select id="serviceCategoryId" name="serviceCategoryId" class="form-control" required>
+                                <option value="" th:text="#{staff.services.form.category.select}">-- Select Category --</option>
+                                <option th:each="category : ${categories}"
+                                        th:value="${category.id}"
+                                        th:text="${category.name}"
+                                        th:selected="${service.serviceCategory.id == category.id}">Category</option>
+                            </select>
+                            <div class="error-message" id="serviceCategoryIdError" th:text="#{staff.services.form.category.error}">Service category is required</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="serviceType" class="form-label required">
+                                <i class="fas fa-layer-group me-2"></i>
+                                <span th:text="#{staff.services.form.type}">Service Type</span>
+                            </label>
+                            <select id="serviceType" name="serviceType" class="form-control" required>
+                                <option value="" th:text="#{staff.services.form.type.select}">-- Select Type --</option>
+                                <option value="SINGLE" th:selected="${service.serviceType.name() == 'SINGLE'}" th:text="#{staff.services.form.type.single}">Single</option>
+                                <option value="COMBO" th:selected="${service.serviceType.name() == 'COMBO'}" th:text="#{staff.services.form.type.combo}">Combo</option>
+                            </select>
+                            <div class="error-message" id="serviceTypeError" th:text="#{staff.services.form.type.error}">Service type is required</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="servicePrice" class="form-label required">
+                                <i class="fas fa-dollar-sign me-2"></i>
+                                <span th:text="#{staff.services.form.price}">Service Price (VND)</span>
+                            </label>
+                            <input type="number" id="servicePrice" name="servicePrice" class="form-control" min="0" step="1000"
+                                   th:value="${service.servicePrice}"
+                                   th:placeholder="#{staff.services.form.price.placeholder}" required>
+                            <div class="error-message" id="servicePriceError" th:text="#{staff.services.form.price.error}">Service price is required and must be a positive number</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="durationMinutes" class="form-label required">
+                                <i class="fas fa-clock me-2"></i>
+                                <span th:text="#{staff.services.form.duration}">Duration (minutes)</span>
+                            </label>
+                            <input type="number" id="durationMinutes" name="durationMinutes" class="form-control" min="1" max="32767"
+                                   th:value="${service.durationMinutes}"
+                                   th:placeholder="#{staff.services.form.duration.placeholder}" required>
+                            <div class="error-message" id="durationMinutesError" th:text="#{staff.services.form.duration.error}">Duration is required and must be between 1 and 32767 minutes</div>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label for="serviceDescription" class="form-label">
+                                <i class="fas fa-align-left me-2"></i>
+                                <span th:text="#{staff.services.form.description}">Service Description</span>
+                            </label>
+                            <textarea id="serviceDescription" name="serviceDescription" class="form-control" rows="4"
+                                      th:text="${service.serviceDescription}"
+                                      th:placeholder="#{staff.services.form.description.placeholder}"></textarea>
+                        </div>
+
+
+                        <div class="form-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" id="activeStatus" name="activeStatus" value="true"
+                                       th:checked="${service.activeStatus}">
+                                <span th:text="#{staff.services.form.status}">Active Status</span>
+                            </label>
+                        </div>
+
+
+                        <div class="form-actions">
+                            <button type="button" class="btn btn-secondary" th:onclick="'window.location.href=\'' + @{/staff/service/list} + '\''">
+                                <i class="fas fa-times me-2"></i>
+                                <span th:text="#{btn.cancel}">Cancel</span>
+                            </button>
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save me-2"></i>
+                                <span th:text="#{btn.update}">Update Service</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
+    </div>
 
-        <div class="button-group">
-            <button type="submit" class="btn btn-primary">Update Service</button>
-            <button type="button" class="btn btn-secondary" onclick="window.location.href='/staff/service/list'">Cancel</button>
-        </div>
-    </form>
 
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+   
+    <!-- Staff Scripts Fragment -->
+    <div th:replace="fragments/staff-sidebar :: staff-scripts"></div>
+   
     <script>
         document.getElementById('editServiceForm').addEventListener('submit', function(event) {
             let isValid = true;
+
 
             // Validate service name
             const serviceName = document.getElementById('serviceName');
@@ -184,6 +167,7 @@
                 serviceNameError.style.display = 'none';
             }
 
+
             // Validate service category
             const serviceCategoryId = document.getElementById('serviceCategoryId');
             const serviceCategoryIdError = document.getElementById('serviceCategoryIdError');
@@ -195,6 +179,7 @@
                 serviceCategoryId.classList.remove('invalid');
                 serviceCategoryIdError.style.display = 'none';
             }
+
 
             // Validate service type
             const serviceType = document.getElementById('serviceType');
@@ -208,6 +193,7 @@
                 serviceTypeError.style.display = 'none';
             }
 
+
             // Validate service price
             const servicePrice = document.getElementById('servicePrice');
             const servicePriceError = document.getElementById('servicePriceError');
@@ -219,6 +205,7 @@
                 servicePrice.classList.remove('invalid');
                 servicePriceError.style.display = 'none';
             }
+
 
             // Validate duration minutes
             const durationMinutes = document.getElementById('durationMinutes');
@@ -233,11 +220,13 @@
                 durationMinutesError.style.display = 'none';
             }
 
+
             if (!isValid) {
                 event.preventDefault();
                 alert('Please correct the errors in the form before submitting.');
             }
         });
+
 
         // Real-time validation on input
         document.getElementById('serviceName').addEventListener('input', function() {
@@ -247,12 +236,14 @@
             }
         });
 
+
         document.getElementById('serviceCategoryId').addEventListener('change', function() {
             if (this.value) {
                 this.classList.remove('invalid');
                 document.getElementById('serviceCategoryIdError').style.display = 'none';
             }
         });
+
 
         document.getElementById('serviceType').addEventListener('change', function() {
             if (this.value) {
@@ -261,12 +252,14 @@
             }
         });
 
+
         document.getElementById('servicePrice').addEventListener('input', function() {
             if (this.value && parseInt(this.value) >= 0) {
                 this.classList.remove('invalid');
                 document.getElementById('servicePriceError').style.display = 'none';
             }
         });
+
 
         document.getElementById('durationMinutes').addEventListener('input', function() {
             const duration = parseInt(this.value);

--- a/backend/SLLBackend/src/main/resources/templates/staff-service-list.html
+++ b/backend/SLLBackend/src/main/resources/templates/staff-service-list.html
@@ -1,205 +1,153 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}">
 <head>
     <meta charset="UTF-8" />
-    <title>Staff - Manage Services</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 20px;
-        }
-        .header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 20px;
-        }
-        .create-btn {
-            padding: 10px 20px;
-            background: #28a745;
-            color: white;
-            text-decoration: none;
-            border-radius: 4px;
-        }
-        .create-btn:hover {
-            background: #218838;
-        }
-        .alert {
-            padding: 12px;
-            margin-bottom: 20px;
-            border-radius: 4px;
-        }
-        .alert-success {
-            background: #d4edda;
-            color: #155724;
-            border: 1px solid #c3e6cb;
-        }
-        .alert-error {
-            background: #f8d7da;
-            color: #721c24;
-            border: 1px solid #f5c6cb;
-        }
-        .search-bar {
-            background: #f9f9f9;
-            padding: 20px;
-            border-radius: 8px;
-            margin-bottom: 20px;
-            border: 1px solid #ddd;
-        }
-        .filter-group {
-            margin-bottom: 15px;
-        }
-        .filter-group label {
-            display: block;
-            font-weight: bold;
-            margin-bottom: 5px;
-        }
-        .checkbox-group {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 15px;
-        }
-        .checkbox-item {
-            display: flex;
-            align-items: center;
-        }
-        .checkbox-item input {
-            margin-right: 5px;
-        }
-        .search-buttons {
-            margin-top: 15px;
-        }
-        .search-buttons button {
-            padding: 8px 16px;
-            margin-right: 10px;
-            cursor: pointer;
-            border: none;
-            border-radius: 4px;
-        }
-        .search-btn {
-            background: #007bff;
-            color: white;
-        }
-        .search-btn:hover {
-            background: #0056b3;
-        }
-        .reset-btn {
-            background: #6c757d;
-            color: white;
-        }
-        .reset-btn:hover {
-            background: #545b62;
-        }
-        table { 
-            border-collapse: collapse; 
-            width: 100%; 
-        }
-        th, td { 
-            border: 1px solid #ddd; 
-            padding: 8px; 
-            text-align: left;
-        }
-        th { 
-            background: #f4f4f4; 
-        }
-        tr:hover {
-            background: #f5f5f5;
-        }
-        .edit-link {
-            color: #007bff;
-            text-decoration: none;
-            margin-right: 10px;
-        }
-        .edit-link:hover {
-            text-decoration: underline;
-        }
-    </style>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title th:text="#{staff.services.title} + ' | ' + #{app.name}">Staff - Manage Services | Salon Loan Loan</title>
+   
+    <!-- Bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" />
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+    <!-- Page CSS -->
+    <link rel="stylesheet" th:href="@{/css/staff-service-list.css}">
+    <!-- Staff Sidebar CSS -->
+    <link rel="stylesheet" th:href="@{/css/staff-sidebar.css}">
 </head>
 <body>
-    <div class="header">
-        <h1>Staff - Manage Services</h1>
-        <a href="/staff/service/create" class="create-btn">+ Create New Service</a>
-    </div>
+    <div class="d-flex">
+        <!-- Sidebar Fragment -->
+        <div th:replace="fragments/staff-sidebar :: staff-sidebar"></div>
 
-    <!-- Success/Error Messages -->
-    <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
-    <div th:if="${errorMessage}" class="alert alert-error" th:text="${errorMessage}"></div>
 
-    <!-- Search and Filter Bar -->
-    <div class="search-bar">
-        <form method="get" action="/staff/service/list">
-            <div class="filter-group">
-                <label for="search-name">Search by Name:</label>
-                <input type="text" id="search-name" name="name" 
-                       th:value="${searchName}" 
-                       placeholder="Enter service name..."
-                       style="width: 100%; padding: 8px; border: 1px solid #ddd; border-radius: 4px;">
-            </div>
+        <!-- Main Content -->
+        <div class="main-content">
+            <!-- Header Fragment with Add Service Button -->
+            <div th:replace="fragments/staff-sidebar :: staff-header-with-add-service"></div>
 
-            <div class="filter-group">
-                <label>Service Type:</label>
-                <div class="checkbox-group">
-                    <div class="checkbox-item">
-                        <input type="checkbox" id="type-single" name="types" value="SINGLE" 
-                               th:checked="${selectedTypes != null and selectedTypes.contains('SINGLE')}">
-                        <label for="type-single">Single</label>
-                    </div>
-                    <div class="checkbox-item">
-                        <input type="checkbox" id="type-combo" name="types" value="COMBO"
-                               th:checked="${selectedTypes != null and selectedTypes.contains('COMBO')}">
-                        <label for="type-combo">Combo</label>
-                    </div>
+
+            <!-- Content -->
+            <div class="content">
+                <h1 class="page-title" th:text="#{staff.services.title}">Manage Services</h1>
+
+
+                <!-- Success/Error Messages -->
+                <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
+                    <i class="fa-solid fa-check-circle me-2"></i>
+                    <span th:text="${successMessage}">Success message</span>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                </div>
+                <div th:if="${errorMessage}" class="alert alert-danger alert-dismissible fade show" role="alert">
+                    <i class="fa-solid fa-exclamation-circle me-2"></i>
+                    <span th:text="${errorMessage}">Error message</span>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                </div>
+
+
+                <!-- Search and Filter Section -->
+                <div class="search-section">
+                    <form method="get" th:action="@{/staff/service/list}">
+                        <div class="search-row">
+                            <div class="search-group">
+                                <label for="search-name" th:text="#{staff.services.search.name}">Search by Name:</label>
+                                <input type="text" id="search-name" name="name"
+                                       th:value="${searchName}"
+                                       th:placeholder="#{staff.services.search.placeholder}">
+                            </div>
+                            <div class="search-group">
+                                <label th:text="#{staff.services.filter.type}">Service Type:</label>
+                                <div class="radio-group">
+                                    <label>
+                                        <input type="radio" name="serviceType" value="SINGLE"
+                                               th:checked="${selectedTypes != null and selectedTypes.contains('SINGLE')}">
+                                        <span th:text="#{staff.services.filter.single}">Single</span>
+                                    </label>
+                                    <label>
+                                        <input type="radio" name="serviceType" value="COMBO"
+                                               th:checked="${selectedTypes != null and selectedTypes.contains('COMBO')}">
+                                        <span th:text="#{staff.services.filter.combo}">Combo</span>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="search-row">
+                            <div class="search-group category-group">
+                                <label th:text="#{staff.services.filter.category}">Service Category:</label>
+                                <div class="checkbox-group">
+                                    <div class="checkbox-item" th:each="category : ${allCategories}">
+                                        <input type="checkbox" th:id="'category-' + ${category.id}"
+                                               name="categories" th:value="${category.id}"
+                                               th:checked="${selectedCategories != null and selectedCategories.contains(category.id)}">
+                                        <label th:for="'category-' + ${category.id}" th:text="${category.name}">Category</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="button-group">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-search me-2"></i>
+                                <span th:text="#{btn.search}">Search</span>
+                            </button>
+                            <button type="button" class="btn btn-secondary" th:onclick="'window.location.href=\'' + @{/staff/service/list} + '\''">
+                                <i class="fas fa-undo me-2"></i>
+                                <span th:text="#{btn.reset}">Reset</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+
+
+                <!-- Service List Table -->
+                <div class="table-container">
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                <th th:text="#{staff.services.table.id}">ID</th>
+                                <th th:text="#{staff.services.table.name}">Name</th>
+                                <th th:text="#{staff.services.table.category}">Category</th>
+                                <th th:text="#{staff.services.table.type}">Type</th>
+                                <th th:text="#{staff.services.table.price}">Price</th>
+                                <th th:text="#{staff.services.table.duration}">Duration (min)</th>
+                                <th th:text="#{staff.services.table.status}">Active</th>
+                                <th th:text="#{staff.services.table.actions}">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr th:each="svc : ${services}">
+                                <td th:text="${svc.id}">1</td>
+                                <td th:text="${svc.serviceName}">Service name</td>
+                                <td th:text="${svc.serviceCategory != null ? svc.serviceCategory.name : 'N/A'}">Category</td>
+                                <td>
+                                    <span th:if="${svc.serviceType == 'SINGLE'}" class="badge bg-primary" th:text="#{staff.services.type.single}">Single</span>
+                                    <span th:if="${svc.serviceType == 'COMBO'}" class="badge bg-success" th:text="#{staff.services.type.combo}">Combo</span>
+                                    <span th:unless="${svc.serviceType == 'SINGLE' or svc.serviceType == 'COMBO'}" class="badge bg-secondary" th:text="${svc.serviceType}">Unknown</span>
+                                </td>
+                                <td th:text="${svc.servicePrice}">0</td>
+                                <td th:text="${svc.durationMinutes}">0</td>
+                                <td>
+                                    <span th:if="${svc.activeStatus}" class="badge bg-success" th:text="#{label.active}">Active</span>
+                                    <span th:unless="${svc.activeStatus}" class="badge bg-secondary" th:text="#{label.inactive}">Inactive</span>
+                                </td>
+                                <td>
+                                    <a th:href="@{/staff/service/edit/{id}(id=${svc.id})}" class="btn btn-sm btn-outline-primary">
+                                        <i class="fas fa-edit me-1"></i>
+                                        <span th:text="#{btn.edit}">Edit</span>
+                                    </a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
-
-            <div class="filter-group">
-                <label>Service Category:</label>
-                <div class="checkbox-group">
-                    <div class="checkbox-item" th:each="category : ${allCategories}">
-                        <input type="checkbox" th:id="'category-' + ${category.id}" 
-                               name="categories" th:value="${category.id}"
-                               th:checked="${selectedCategories != null and selectedCategories.contains(category.id)}">
-                        <label th:for="'category-' + ${category.id}" th:text="${category.name}">Category</label>
-                    </div>
-                </div>
-            </div>
-
-            <div class="search-buttons">
-                <button type="submit" class="search-btn">Search</button>
-                <button type="button" class="reset-btn" onclick="window.location.href='/staff/service/list'">Reset</button>
-            </div>
-        </form>
+        </div>
     </div>
 
-    <!-- Services Table -->
-    <table>
-        <thead>
-            <tr>
-                <th>ID</th>
-                <th>Name</th>
-                <th>Category</th>
-                <th>Type</th>
-                <th>Price</th>
-                <th>Duration (min)</th>
-                <th>Active</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr th:each="svc : ${services}">
-                <td th:text="${svc.id}">1</td>
-                <td th:text="${svc.serviceName}">Service name</td>
-                <td th:text="${svc.serviceCategory != null ? svc.serviceCategory.name : 'N/A'}">Category</td>
-                <td th:text="${svc.serviceType}">SINGLE</td>
-                <td th:text="${svc.servicePrice}">0</td>
-                <td th:text="${svc.durationMinutes}">0</td>
-                <td th:text="${svc.activeStatus}">false</td>
-                <td>
-                    <a th:href="@{/staff/service/edit/{id}(id=${svc.id})}" class="edit-link">Edit</a>
-                </td>
-            </tr>
-        </tbody>
-    </table>
 
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- Staff Scripts Fragment -->
+    <div th:replace="fragments/staff-sidebar :: staff-scripts"></div>
 </body>
 </html>


### PR DESCRIPTION
- Added staff service pages: create, edit, and list (HTML templates)
- Implemented separate CSS files for each service page
- Built consistent layout following shared sidebar and header components
- Enhanced form and table UI for better usability and readability
- Prepared service templates for future integration with backend data